### PR TITLE
Fix description of how block limit is computed from votes

### DIFF
--- a/discussion.md
+++ b/discussion.md
@@ -236,7 +236,7 @@ Protocol changes proposed:
 7. Changing the 1MB limit is accomplished in a manner similar to BIP 34, a one-way lock-in upgrade with a 12,000 block (3 month) threshold by 90% of the blocks.
 8. Limit increase or decrease may not exceed 2x in any one step.
 9. Limit may not decrease below 1MB.
-10. Miners vote by encoding ‘BV’+BlockSizeRequestValue into coinbase scriptSig, e.g. “/BV8000000/” to vote for 8M. Votes are evaluated by dropping bottom 20% and top 20%, and then the most common floor (minimum) is chosen.
+10. Miners vote by encoding ‘BV’+BlockSizeRequestValue into coinbase scriptSig, e.g. “/BV8000000/” to vote for 8M. The 20th percentile vote is the new block size limit.
 
 This creates a framework whereby the network may increase the block size
 by consensus, a lower and less politically risky hurdle than hard fork.


### PR DESCRIPTION
"Most common floor" is not a well known term. There has been much confusion about how BIP 100 works because of this line.

Jeff has stated that he meant 20th percentile here: http://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-August/010681.html
