### PR TITLE
Changed voting procedure to require an 80% consensus.

### DIFF
--- a/discussion.md
+++ b/discussion.md
@@ -236,7 +236,9 @@ Protocol changes proposed:
 7. Changing the 1MB limit is accomplished in a manner similar to BIP 34, a one-way lock-in upgrade with a 12,000 block (3 month) threshold by 90% of the blocks.
 8. Limit increase or decrease may not exceed 2x in any one step.
 9. Limit may not decrease below 1MB.
-10. Miners vote by encoding ‘BV’+BlockSizeRequestValue into coinbase scriptSig, e.g. “/BV8000000/” to vote for 8M. The 20th percentile vote is the new block size limit.
+10. Miners vote by encoding ‘BV’+BlockSizeRequestValue into coinbase scriptSig, e.g. “/BV8000000/” to vote for 8M. An 80% consensus is required to change the block size.
+11. In the case of a block size increase, the 20th percentile vote is the new block size limit.
+12. In the case of a block size decrease, the 80th percentile vote is the new block size limit.
 
 This creates a framework whereby the network may increase the block size
 by consensus, a lower and less politically risky hurdle than hard fork.


### PR DESCRIPTION
(Rebased pull request to use the simpler language.  )

This PR would change the voting procedure to always require a >80% consensus to change the block size in either direction.

The purpose of this is to prevent the block size limit from "jittering" up and down every voting period.  The block size should have have significant bias towards not changing.
