### PR TITLE
Change title

### DIFF
--- a/bip-0100.mediawiki
+++ b/bip-0100.mediawiki
@@ -1,6 +1,6 @@
 <pre>
   BIP: 100
-  Title: Block v4, floating block size hard limit
+  Title: Floating block size hard limit
   Author: Jeff Garzik <jgarzik@gmail.com>
   Status: Draft
   Type: Standards Track


### PR DESCRIPTION
Block v4 is a deployment assumption. It should not be part of the title.
