### PR TITLE
Use 50th percentile for block size reductions.

### DIFF
--- a/bip-0100.mediawiki
+++ b/bip-0100.mediawiki
@@ -17,7 +17,8 @@ Replace static 1M block size hard limit with a hard limit that floats between 1M
 # Eliminate 1M limit as impediment to adoption.
 # Execute a hard fork network upgrade within safety rails, gathering data and experience for future upgrades.
 # Contain checks-and-balances that users must opt into, to enable system activation and growth.
-# Validated growth: a large majority (80%) is required to change the value.
+# Validated growth: a large majority (80%) is required to increase the value.
+# Avoid incentives to soft fork: a majority of miners somewhat above 50% can force a soft fork to reduce the block size (possibly permanently).  Allowing 50% of miners to vote to reduce the blocksize removes the incentive to soft fork.
 
 ==Specification==
 
@@ -31,8 +32,8 @@ Replace static 1M block size hard limit with a hard limit that floats between 1M
 ### Absent/invalid votes are counted as votes for the current hardLimit. Out of range votes are counted as the nearest in-range value.
 ### Votes are limited to +/- 20% of the current hardLimit.
 ### Sort the votes from the previous 12,000 blocks from lowest to highest.
-### The raise value is defined as a vote for 2400th highest block (20th percentile).
-### The lower value is defined as a vote for 9600th highest block (80th percentile).
+### The raise value is defined as a vote for 2400th block in the sorted list (20th percentile).
+### The lower value is defined as a vote for 6000th block in the sorted list (median).
 ### If the raise value is higher than current hardLimit, the new limit becomes the raise value.
 ### If the lower value is lower than current hardLimit, the new limit becomes the lower value.
 ### Otherwise, hardLimit is unchanged.

--- a/discussion.md
+++ b/discussion.md
@@ -236,7 +236,7 @@ Protocol changes proposed:
 7. Limit may not decrease below 1MB, nor exceed 32MB.
 8. Miners vote by encoding ‘B’+BlockSizeRequestValue into coinbase scriptSig, e.g. “/B8000000/” or "/B8M/" to vote for 8M. An 80% consensus is required to change the block size.
 9. In the case of a block size increase, the 20th percentile vote is the new block size limit.
-10. In the case of a block size decrease, the 80th percentile vote is the new block size limit.
+10. In the case of a block size decrease, the median (50th percentile) vote is the new block size limit.
 
 This creates a framework whereby the network may increase the block size
 by consensus, a lower and less politically risky hurdle than hard fork.
@@ -256,6 +256,7 @@ This BIP accomplishes several goals:
 * Get hard fork risk out of the way early.
 * KISS solution, in terms of code changes.
 * Upgrade path, yet constrained until problem & solution better understood.
+* Stability: avoids creating an incentive for proponents of a block size decrease at some point in the future to force a soft fork abandoning BIP100 by permitting a simply majority of miners to always force a reduction in block size
 
 This introduces friction into the block size increase process - making
 it changeable, yet giving participants in the system sufficient time to


### PR DESCRIPTION
I'm a bit concerned that setting the bar so high for block size reductions would create instability.

If, at some point in the future (when block size is much higher than at present) a majority (>50%) of miners wanted to reduce the block size, then the fact that BIP100 as currently drafted would require 80% of miners to agree to the reduction would create an incentive for the miners to force the reduction by a soft fork, quite possibly permanently reducing the block size.  This would then require us to go through the whole hard fork process again if we ever want to increase it again further down the line.

Since a soft fork can be forced by a  >50% (in practice would require a modest margin above 50%, but nowhere near as high as 80%) I propose we use 50% for block size reductions, so helping to ensure stability by removing any incentive to soft fork to reduce the block size.

I also fixed the wording for calcultating percentiles: we've sorted the votes lowest to highest.  The 20th percentile is therefore the 2400th block.  Taking the 2400th _highest_ block doesn't make sense; it would mean effectively ignoring the sort but just taking the 80th percentile (not the 20th).
