### PR TITLE
nb. of blocks adapted to new "2016 blocks" hard limit update interval

### DIFF
--- a/bip-0100.mediawiki
+++ b/bip-0100.mediawiki
@@ -30,9 +30,9 @@ Replace static 1M block size hard limit with a hard limit that floats between 1M
 ## Calculation:
 ### Absent/invalid votes are counted as votes for the current hardLimit. Out of range votes are counted as the nearest in-range value.
 ### Votes are limited to +/- 20% of the current hardLimit.
-### Sort the votes from the previous 12,000 blocks from lowest to highest.
-### The raise value is defined as a vote for 2400th highest block (20th percentile).
-### The lower value is defined as a vote for 9600th highest block (80th percentile).
+### Sort the votes from the previous 2,016 blocks from lowest to highest.
+### The raise value is defined as the 404th lowest vote in the sorted list of 2,016 votes (20th percentile).
+### The lower value is defined as the 1,613rd lowest vote in the sorted list of 2,016 votes (80th percentile).
 ### If the raise value is higher than current hardLimit, the new limit becomes the raise value.
 ### If the lower value is lower than current hardLimit, the new limit becomes the lower value.
 ### Otherwise, hardLimit is unchanged.


### PR DESCRIPTION
I spotted some inconsistencies, because BIP100 switched from 12,000 to 2,016 blocks, but not all numbers have been adapted accordingly. So I just fixed it.
Note: The 1613rd lowest value could also be called the 404th highest value.
