### PR TITLE
Remove artifact (side-effect) of "unfair" voting

### DIFF
--- a/bip-0100.mediawiki
+++ b/bip-0100.mediawiki
@@ -30,9 +30,9 @@ Replace static 1M block size hard limit with a hard limit that floats between 1M
 ## Calculation:
 ### Absent/invalid votes are counted as votes for the current hardLimit. Out of range votes are counted as the nearest in-range value.
 ### Votes are limited to +/- 20% of the current hardLimit.
-### Sort the votes from the previous 12,000 blocks from lowest to highest.
-### The raise value is defined as a vote for 2400th highest block (20th percentile).
-### The lower value is defined as a vote for 9600th highest block (80th percentile).
+### Sort the votes from the previous 12,096 blocks from lowest to highest.
+### The raise value is defined as the 2420th lowest vote (20th percentile).
+### The lower value is defined as the 9677th lowest (=2420th highest) vote (80th percentile).
 ### If the raise value is higher than current hardLimit, the new limit becomes the raise value.
 ### If the lower value is lower than current hardLimit, the new limit becomes the lower value.
 ### Otherwise, hardLimit is unchanged.


### PR DESCRIPTION
With the "12,000", the votes of blocks 97..2016 of each 2016 interval have 20% more weight than the votes of blocks 1..96, because they would influence the next 6 block size limit adjustments instead of only 5. [ 12,000 = 5*2016 + (2016-96) ]
Hence change the constant 12,000 to 6 \* 2,016 = 12,096, and adapt the 20% / 80% percentiles accordingly.

The other change is a modification of the phrasing, to define the percentiles more clearly.

Note: I propose to pull https://github.com/jgarzik/bip100/pull/14 instead of this one. Only pull this one if https://github.com/jgarzik/bip100/pull/14 is not accepted.
