### PR TITLE
Parameterization, clarification

### DIFF
--- a/bip-0100.mediawiki
+++ b/bip-0100.mediawiki
@@ -15,7 +15,7 @@
 
 ==Abstract==
 
-Replace the static 1M block size hard limit with a hard limit set by coinbase vote, conducted on the same schedule as difficulty retargeting.
+Replace the static base block size hard limit with a hard limit set by coinbase vote, conducted on the same schedule as difficulty retargeting.
 
 ==Motivation==
 
@@ -28,7 +28,7 @@ The system is compatible with emergent consensus, but whereas under that system 
 ==Specification==
 
 ===Dynamic Maximum Block Size===
-# Initial value of <code>hardLimit</code> is 1000000 bytes, preserving current system.
+# Initial value of <code>hardLimit</code> is implementation parameter 1 (IP1).
 # Changing <code>hardLimit</code> is accomplished by encoding a proposed value, a vote, within a block's coinbase scriptSig, and by processing the votes contained in the previous retargeting period.<br /><br />
 ## Vote encoding
 ### A vote is represented as a megabyte value using the BIP100 pattern<br /><br /><code>/BIP100/B[0-9]+/</code><br /><br />Example: <code>/BIP100/B8/</code> is a vote for a 8000000-byte <code>hardLimit</code>.<br /><br />
@@ -38,7 +38,7 @@ The system is compatible with emergent consensus, but whereas under that system 
 ### If no BIP100 pattern is matched, the first matching emergent consensus pattern <code>/EB[0-9]+/</code>, if any, is accepted as the megabyte vote.<br /><br />
 ## Maximum block size recalculation
 ### A <code>new hardLimit</code> is calculated after each difficulty adjustment period of 2016 blocks, and applies to the next 2016 blocks.
-### Absent/zero-valued votes are counted as votes for the <code>current hardLimit</code>.
+### Absent/zero-valued votes are counted as votes for the <code>current hardLimit</code>, which is defined as the <code>hardLimit</code> of the last block in the previous interval.
 ### The votes of the previous 2016 blocks are sorted by megabyte vote.
 ### Raising <code>hardLimit</code><br /><br />
 #### The <code>raise value</code> is defined as the vote of the 1512th highest block, converted to bytes.
@@ -61,11 +61,11 @@ The system is compatible with emergent consensus, but whereas under that system 
 
 ==Deployment==
 
-This BIP is presumed deployed and activated as of block height 449568 by implementing nodes on the bitcoin mainnet. It has no effect until a raise value different from 1M is observed, which requires at least 1512 of 2016 blocks to vote differently from 1M.
+This BIP is presumed deployed and activated as of a past block height by implementing nodes on the bitcoin mainnet.  The activation height is implementation parameter 2 (IP2).  It has no effect until a raise value different from IP1 is observed, which requires at least 1512 of 2016 blocks to vote differently from IP1.
 
 ==Backward compatibility==
 
-The first block larger than 1M will create a network partition, as nodes with a fixed 1M hard limit reject that block.
+The first block larger than IP1 will create a network partition, as nodes with a fixed IP1 hard limit reject that block.
 
 ==Implementations==
 https://github.com/bitcoinxt/bitcoinxt/pull/188</br>


### PR DESCRIPTION
Starting hardLimit and activation height are changed to implementation parameters.

Current hardLimit is clarified to mean the hardLimit of the last block in the previous interval.  This can matter if some other mechanism is capable of updating the limit.  This actually happened with the Bitcoin Cash fork, which occurred in the middle of a difficulty interval.